### PR TITLE
Optimize performance and memory usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,8 +584,10 @@ dependencies = [
  "log",
  "memmap2",
  "owo-colors",
+ "raw-stdio",
  "serde",
  "serde_json",
+ "utf8-console",
  "wayland-client",
  "wayland-protocols",
 ]
@@ -853,6 +855,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "raw-stdio"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43519c1ec59768518e5bb89bf43743b34853db1580e7d643f88c4e2c8421b57c"
 
 [[package]]
 name = "rayon"
@@ -1173,6 +1181,15 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "utf8-console"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df64c5026a053d587140154b90cefd04934676fa92d27fc4bda53cedfe2622d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "utf8parse"

--- a/kbvm-cli/Cargo.toml
+++ b/kbvm-cli/Cargo.toml
@@ -30,3 +30,5 @@ serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.135"
 isnt = "0.1.0"
 error_reporter = "1.0.0"
+raw-stdio = "0.1.0"
+utf8-console = "0.1.0"

--- a/kbvm-cli/src/compile_rmlvo.rs
+++ b/kbvm-cli/src/compile_rmlvo.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{cli::CompileArgs, expand_rmlvo::RmlvoArgs},
+    crate::{cli::CompileArgs, compile_xkb::format_keymap, expand_rmlvo::RmlvoArgs},
     clap::Args,
     kbvm::xkb::{diagnostic::WriteToLog, Context},
 };
@@ -24,5 +24,5 @@ pub fn main(args: CompileRmlvoArgs) {
         groups.as_deref(),
         options.as_deref(),
     );
-    println!("{}", expanded.format().multiple_actions_per_level(true));
+    format_keymap(expanded.format().multiple_actions_per_level(true));
 }

--- a/kbvm-cli/src/expand_rmlvo.rs
+++ b/kbvm-cli/src/expand_rmlvo.rs
@@ -1,5 +1,5 @@
 use {
-    crate::cli::CompileArgs,
+    crate::{cli::CompileArgs, compile_xkb::format_keymap},
     clap::Args,
     isnt::std_1::vec::IsntVecExt,
     kbvm::xkb::{diagnostic::WriteToLog, rmlvo::Group, Context},
@@ -69,5 +69,5 @@ pub fn main(args: ExpandRmlvoArgs) {
         groups.as_deref(),
         options.as_deref(),
     );
-    println!("{:#}", expanded.format());
+    format_keymap(expanded.format());
 }

--- a/kbvm-cli/src/main.rs
+++ b/kbvm-cli/src/main.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::single_match)]
 
-use log::LevelFilter;
+use {error_reporter::Report, log::LevelFilter};
 
 mod cli;
 mod compile_rmlvo;
@@ -17,5 +17,8 @@ fn main() {
         .filter_level(LevelFilter::Info)
         .parse_default_env()
         .init();
+    if let Err(e) = utf8_console::enable() {
+        log::error!("could not enable UTF-8: {}", Report::new(e));
+    }
     cli::main();
 }

--- a/kbvm-proc/src/clone_with_delta.rs
+++ b/kbvm-proc/src/clone_with_delta.rs
@@ -75,7 +75,7 @@ pub(crate) fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
     let (impl_generics, type_generics, where_clause) = item.generics.split_for_impl();
     let tokens = quote! {
         impl #impl_generics crate::xkb::clone_with_delta::CloneWithDelta for #ident #type_generics #where_clause {
-            fn clone_with_delta(&self, delta: u64) -> Self {
+            fn clone_with_delta(&self, delta: crate::xkb::span::SpanUnit) -> Self {
                 #body
             }
         }

--- a/kbvm/src/xkb.rs
+++ b/kbvm/src/xkb.rs
@@ -84,7 +84,7 @@ mod radio_group;
 pub mod registry;
 mod resolved;
 pub mod rmlvo;
-mod span;
+pub(crate) mod span;
 mod string_cooker;
 #[cfg(feature = "x11")]
 pub mod x11;

--- a/kbvm/src/xkb/clone_with_delta.rs
+++ b/kbvm/src/xkb/clone_with_delta.rs
@@ -37,6 +37,15 @@ where
     }
 }
 
+impl<T> CloneWithDelta for Box<[T]>
+where
+    T: CloneWithDelta,
+{
+    fn clone_with_delta(&self, delta: u64) -> Self {
+        self.iter().map(|t| t.clone_with_delta(delta)).collect()
+    }
+}
+
 macro_rules! copy {
     ($ty:ty) => {
         impl CloneWithDelta for $ty {

--- a/kbvm/src/xkb/clone_with_delta.rs
+++ b/kbvm/src/xkb/clone_with_delta.rs
@@ -1,11 +1,11 @@
-use crate::xkb::span::Span;
+use crate::xkb::span::{Span, SpanUnit};
 
 pub(crate) trait CloneWithDelta: Sized {
-    fn clone_with_delta(&self, delta: u64) -> Self;
+    fn clone_with_delta(&self, delta: SpanUnit) -> Self;
 }
 
 impl CloneWithDelta for Span {
-    fn clone_with_delta(&self, delta: u64) -> Self {
+    fn clone_with_delta(&self, delta: SpanUnit) -> Self {
         *self + delta
     }
 }
@@ -14,7 +14,7 @@ impl<T> CloneWithDelta for Vec<T>
 where
     T: CloneWithDelta,
 {
-    fn clone_with_delta(&self, delta: u64) -> Self {
+    fn clone_with_delta(&self, delta: SpanUnit) -> Self {
         self.iter().map(|t| t.clone_with_delta(delta)).collect()
     }
 }
@@ -23,7 +23,7 @@ impl<T> CloneWithDelta for Option<T>
 where
     T: CloneWithDelta,
 {
-    fn clone_with_delta(&self, delta: u64) -> Self {
+    fn clone_with_delta(&self, delta: SpanUnit) -> Self {
         self.as_ref().map(|t| t.clone_with_delta(delta))
     }
 }
@@ -32,7 +32,7 @@ impl<T> CloneWithDelta for Box<T>
 where
     T: CloneWithDelta,
 {
-    fn clone_with_delta(&self, delta: u64) -> Self {
+    fn clone_with_delta(&self, delta: SpanUnit) -> Self {
         Box::new((**self).clone_with_delta(delta))
     }
 }
@@ -41,7 +41,7 @@ impl<T> CloneWithDelta for Box<[T]>
 where
     T: CloneWithDelta,
 {
-    fn clone_with_delta(&self, delta: u64) -> Self {
+    fn clone_with_delta(&self, delta: SpanUnit) -> Self {
         self.iter().map(|t| t.clone_with_delta(delta)).collect()
     }
 }
@@ -49,7 +49,7 @@ where
 macro_rules! copy {
     ($ty:ty) => {
         impl CloneWithDelta for $ty {
-            fn clone_with_delta(&self, _delta: u64) -> Self {
+            fn clone_with_delta(&self, _delta: SpanUnit) -> Self {
                 *self
             }
         }

--- a/kbvm/src/xkb/code_map.rs
+++ b/kbvm/src/xkb/code_map.rs
@@ -1,5 +1,8 @@
 use {
-    crate::xkb::{code::Code, span::Span},
+    crate::xkb::{
+        code::Code,
+        span::{Span, SpanUnit},
+    },
     hashbrown::HashMap,
     std::{path::PathBuf, sync::Arc},
 };
@@ -15,7 +18,7 @@ struct CodeRange {
     code: Code,
     file: Option<Arc<PathBuf>>,
     canonical_idx: Option<usize>,
-    lines: Option<Vec<u64>>,
+    lines: Option<Vec<SpanUnit>>,
     include_span: Option<Span>,
 }
 
@@ -23,8 +26,8 @@ pub(crate) struct CodeInfo<'a> {
     pub(crate) code: &'a Code,
     pub(crate) span: Span,
     pub(crate) file: Option<&'a Arc<PathBuf>>,
-    pub(crate) lines: &'a [u64],
-    pub(crate) lines_offset: u64,
+    pub(crate) lines: &'a [SpanUnit],
+    pub(crate) lines_offset: SpanUnit,
     pub(crate) include_span: Option<Span>,
 }
 
@@ -42,7 +45,7 @@ impl CodeRange {
                 break;
             };
             code = &code[pos + 1..];
-            lo += pos as u64 + 1;
+            lo += pos as SpanUnit + 1;
             lines.push(lo);
         }
         self.lines = Some(lines);
@@ -63,7 +66,7 @@ impl CodeMap {
             .unwrap_or_default();
         let span = Span {
             lo,
-            hi: lo + code.len() as u64,
+            hi: lo + code.len() as SpanUnit,
         };
         let canonical_idx = self
             .canonical_idx

--- a/kbvm/src/xkb/compose/parser.rs
+++ b/kbvm/src/xkb/compose/parser.rs
@@ -16,7 +16,7 @@ use {
             diagnostic::{DiagnosticKind, DiagnosticSink},
             interner::Interner,
             meaning::{Meaning, MeaningCache},
-            span::{SpanExt, Spanned},
+            span::{SpanExt, SpanUnit, Spanned},
         },
         Keysym, ModifierMask,
     },
@@ -130,7 +130,7 @@ impl Parser<'_, '_, '_> {
             for (offset, &b) in bytes.as_bytes().iter().enumerate() {
                 if last_was_percent {
                     last_was_percent = false;
-                    let lo = t.span.lo + offset as u64;
+                    let lo = t.span.lo + offset as SpanUnit;
                     let hi = lo + 2;
                     match b {
                         b'%' => out.push(b'%'),

--- a/kbvm/src/xkb/diagnostic.rs
+++ b/kbvm/src/xkb/diagnostic.rs
@@ -2025,7 +2025,7 @@ impl DiagnosticLocation {
             .map(|l| *l - 1)
             .unwrap_or(info.span.hi - info.lines_offset);
         let in_line_offset = (lo - line_lo) as usize;
-        let in_line_len = (hi.min(line_hi) - lo) as usize;
+        let in_line_len = (hi.min(line_hi).saturating_sub(lo)) as usize;
         let line_lo = (line_lo + info.lines_offset - info.span.lo) as usize;
         let line_hi = (line_hi + info.lines_offset - info.span.lo) as usize;
         let slice = info.code.to_slice().slice(line_lo..line_hi).to_owned();

--- a/kbvm/src/xkb/include/error.rs
+++ b/kbvm/src/xkb/include/error.rs
@@ -2,7 +2,7 @@ use {
     crate::xkb::{
         code_slice::CodeSlice,
         diagnostic::DiagnosticKind,
-        span::{Span, SpanExt, Spanned},
+        span::{Span, SpanExt, SpanUnit, Spanned},
     },
     bstr::ByteSlice,
     thiserror::Error,
@@ -35,7 +35,7 @@ pub(super) fn missing_file_name(span: Span) -> Spanned<ParseIncludeError> {
     ParseIncludeError::MissingFileName.spanned2(span)
 }
 
-pub(super) fn unterminated_map_name(lo: u64, hi: u64) -> Spanned<ParseIncludeError> {
+pub(super) fn unterminated_map_name(lo: SpanUnit, hi: SpanUnit) -> Spanned<ParseIncludeError> {
     ParseIncludeError::UnterminatedMapName.spanned(lo, hi)
 }
 
@@ -43,6 +43,10 @@ pub(super) fn missing_merge_mode(span: Span) -> Spanned<ParseIncludeError> {
     ParseIncludeError::MissingMergeMode.spanned2(span)
 }
 
-pub(super) fn invalid_group(s: &CodeSlice<'_>, lo: u64, hi: u64) -> Spanned<ParseIncludeError> {
+pub(super) fn invalid_group(
+    s: &CodeSlice<'_>,
+    lo: SpanUnit,
+    hi: SpanUnit,
+) -> Spanned<ParseIncludeError> {
     ParseIncludeError::InvalidGroupIndex(s.to_owned()).spanned(lo, hi)
 }

--- a/kbvm/src/xkb/kccgst/ast.rs
+++ b/kbvm/src/xkb/kccgst/ast.rs
@@ -26,7 +26,7 @@ pub(crate) struct FlagWrapper {
 
 #[derive(Default, Debug, CloneWithDelta)]
 pub(crate) struct Flags {
-    pub(crate) flags: Vec<FlagWrapper>,
+    pub(crate) flags: Box<[FlagWrapper]>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, CloneWithDelta)]
@@ -50,7 +50,7 @@ pub(crate) enum ItemType {
 #[derive(Debug, CloneWithDelta)]
 pub(crate) struct CompositeMap {
     pub(crate) name: Option<Spanned<Interned>>,
-    pub(crate) config_items: Vec<Spanned<NestedConfigItem>>,
+    pub(crate) config_items: Box<[Spanned<NestedConfigItem>]>,
 }
 
 #[derive(Debug, CloneWithDelta)]
@@ -81,7 +81,7 @@ pub(crate) struct Keycodes {
 
 #[derive(Debug, CloneWithDelta)]
 pub(crate) struct Decls<T> {
-    pub(crate) decls: Vec<Spanned<Decl<T>>>,
+    pub(crate) decls: Box<[Spanned<Decl<T>>]>,
 }
 
 #[derive(Debug, CloneWithDelta)]
@@ -98,7 +98,7 @@ pub(crate) enum DirectOrIncluded<T> {
 
 #[derive(Debug, CloneWithDelta)]
 pub(crate) struct Included<T> {
-    pub(crate) components: Vec<Component<T>>,
+    pub(crate) components: Box<[Component<T>]>,
 }
 
 #[derive(Debug, CloneWithDelta)]
@@ -194,7 +194,7 @@ pub(crate) struct Var {
 #[derive(Debug, CloneWithDelta)]
 pub(crate) struct InterpretDecl {
     pub(crate) match_: Spanned<InterpretMatch>,
-    pub(crate) vars: Vec<Spanned<VarDecl>>,
+    pub(crate) vars: Box<[Spanned<VarDecl>]>,
 }
 
 #[derive(Debug, CloneWithDelta)]
@@ -219,13 +219,13 @@ pub(crate) struct KeyAliasDecl {
 #[derive(Debug, CloneWithDelta)]
 pub(crate) struct KeyTypeDecl {
     pub(crate) name: Spanned<Interned>,
-    pub(crate) decls: Vec<Spanned<VarDecl>>,
+    pub(crate) decls: Box<[Spanned<VarDecl>]>,
 }
 
 #[derive(Debug, CloneWithDelta)]
 pub(crate) struct KeySymbolsDecl {
     pub(crate) key: Spanned<Interned>,
-    pub(crate) vars: Vec<Spanned<VarOrExpr>>,
+    pub(crate) vars: Box<[Spanned<VarOrExpr>]>,
 }
 
 #[derive(Debug, CloneWithDelta)]
@@ -237,7 +237,7 @@ pub(crate) enum VarOrExpr {
 #[derive(Debug, CloneWithDelta)]
 pub(crate) struct ModMapDecl {
     pub(crate) modifier: Spanned<Interned>,
-    pub(crate) keys: Vec<Spanned<Expr>>,
+    pub(crate) keys: Box<[Spanned<Expr>]>,
 }
 
 #[derive(Debug, CloneWithDelta)]
@@ -250,7 +250,7 @@ pub(crate) struct GroupCompatDecl {
 #[derive(Debug, CloneWithDelta)]
 pub(crate) struct IndicatorMapDecl {
     pub(crate) name: Spanned<Interned>,
-    pub(crate) decls: Vec<Spanned<VarDecl>>,
+    pub(crate) decls: Box<[Spanned<VarDecl>]>,
 }
 
 #[derive(Debug, CloneWithDelta)]
@@ -269,13 +269,13 @@ pub(crate) struct ShapeDecl {
 
 #[derive(Debug, CloneWithDelta)]
 pub(crate) enum ShapeDeclType {
-    OutlineList(Vec<Spanned<Outline>>),
-    CoordList(Vec<Spanned<Coord>>),
+    OutlineList(Box<[Spanned<Outline>]>),
+    CoordList(Box<[Spanned<Coord>]>),
 }
 
 #[derive(Debug, CloneWithDelta)]
 pub(crate) enum Outline {
-    CoordList(Vec<Spanned<Coord>>),
+    CoordList(Box<[Spanned<Coord>]>),
     ExprAssignment(ExprAssignment),
     CoordAssignment(CoordAssignment),
 }
@@ -289,7 +289,7 @@ pub(crate) struct ExprAssignment {
 #[derive(Debug, CloneWithDelta)]
 pub(crate) struct CoordAssignment {
     pub(crate) name: Spanned<Interned>,
-    pub(crate) coords: Spanned<Vec<Spanned<Coord>>>,
+    pub(crate) coords: Spanned<Box<[Spanned<Coord>]>>,
 }
 
 #[derive(Debug, CloneWithDelta)]
@@ -301,7 +301,7 @@ pub(crate) struct Coord {
 #[derive(Debug, CloneWithDelta)]
 pub(crate) struct SectionDecl {
     pub(crate) name: Spanned<Interned>,
-    pub(crate) items: Vec<Spanned<SectionItem>>,
+    pub(crate) items: Box<[Spanned<SectionItem>]>,
 }
 
 #[derive(Debug, CloneWithDelta)]
@@ -315,7 +315,7 @@ pub(crate) enum SectionItem {
 
 #[derive(Debug, CloneWithDelta)]
 pub(crate) struct RowBody {
-    pub(crate) items: Vec<Spanned<RowBodyItem>>,
+    pub(crate) items: Box<[Spanned<RowBodyItem>]>,
 }
 
 #[derive(Debug, CloneWithDelta)]
@@ -326,7 +326,7 @@ pub(crate) enum RowBodyItem {
 
 #[derive(Debug, CloneWithDelta)]
 pub(crate) struct Keys {
-    pub(crate) keys: Vec<Spanned<Key>>,
+    pub(crate) keys: Box<[Spanned<Key>]>,
 }
 
 #[derive(Debug, CloneWithDelta)]
@@ -337,13 +337,13 @@ pub(crate) enum Key {
 
 #[derive(Debug, CloneWithDelta)]
 pub(crate) struct KeyExprs {
-    pub(crate) exprs: Vec<Spanned<VarOrExpr>>,
+    pub(crate) exprs: Box<[Spanned<VarOrExpr>]>,
 }
 
 #[derive(Debug, CloneWithDelta)]
 pub(crate) struct OverlayDecl {
     pub(crate) name: Spanned<Interned>,
-    pub(crate) items: Vec<Spanned<OverlayItem>>,
+    pub(crate) items: Box<[Spanned<OverlayItem>]>,
 }
 
 #[derive(Debug, CloneWithDelta)]
@@ -356,12 +356,12 @@ pub(crate) struct OverlayItem {
 pub(crate) struct DoodadDecl {
     pub(crate) ty: Spanned<DoodadType>,
     pub(crate) name: Spanned<Interned>,
-    pub(crate) decls: Vec<Spanned<VarDecl>>,
+    pub(crate) decls: Box<[Spanned<VarDecl>]>,
 }
 
 #[derive(Debug, CloneWithDelta)]
 pub(crate) struct VModDecl {
-    pub(crate) defs: Vec<Spanned<VModDef>>,
+    pub(crate) defs: Box<[Spanned<VModDef>]>,
 }
 
 #[derive(Debug, CloneWithDelta)]
@@ -374,7 +374,7 @@ pub(crate) struct VModDef {
 pub(crate) struct Include {
     pub(crate) mm: Spanned<MergeMode>,
     pub(crate) path: Spanned<Interned>,
-    pub(crate) loaded: Option<Vec<LoadedInclude>>,
+    pub(crate) loaded: Option<Box<[LoadedInclude]>>,
 }
 
 #[derive(Debug, CloneWithDelta)]
@@ -446,14 +446,14 @@ pub(crate) enum Expr {
     Div(Box<Spanned<Expr>>, Box<Spanned<Expr>>),
     Add(Box<Spanned<Expr>>, Box<Spanned<Expr>>),
     Sub(Box<Spanned<Expr>>, Box<Spanned<Expr>>),
-    BracketList(Vec<Spanned<Expr>>),
-    BraceList(Vec<Spanned<Expr>>),
+    BracketList(Box<[Spanned<Expr>]>),
+    BraceList(Box<[Spanned<Expr>]>),
 }
 
 #[derive(Debug, CloneWithDelta)]
 pub(crate) struct Call {
     pub(crate) path: Spanned<Path>,
-    pub(crate) args: Vec<Spanned<CallArg>>,
+    pub(crate) args: Box<[Spanned<CallArg>]>,
 }
 
 #[derive(Debug, CloneWithDelta)]
@@ -473,7 +473,7 @@ impl Path {
 #[derive(Debug, CloneWithDelta)]
 pub(crate) struct PathComponent {
     pub(crate) ident: Spanned<Interned>,
-    pub(crate) index: Option<PathIndex>,
+    pub(crate) index: Option<Box<PathIndex>>,
 }
 
 #[derive(Debug, CloneWithDelta)]

--- a/kbvm/src/xkb/kccgst/formatter.rs
+++ b/kbvm/src/xkb/kccgst/formatter.rs
@@ -883,15 +883,20 @@ impl Format for Path {
     where
         W: Write,
     {
-        for (idx, component) in self.components.iter().enumerate() {
-            if idx > 0 {
-                f.write_all(".")?;
-            }
-            f.write_interned(component.ident.val)?;
-            if let Some(idx) = &component.index {
-                f.write_all("[")?;
-                idx.index.val.format(f)?;
-                f.write_all("]")?;
+        match self {
+            Path::One(i) => f.write_interned(*i)?,
+            Path::Any(components) => {
+                for (idx, component) in components.iter().enumerate() {
+                    if idx > 0 {
+                        f.write_all(".")?;
+                    }
+                    f.write_interned(component.ident.val)?;
+                    if let Some(idx) = &component.index {
+                        f.write_all("[")?;
+                        idx.index.val.format(f)?;
+                        f.write_all("]")?;
+                    }
+                }
             }
         }
         Ok(())

--- a/kbvm/src/xkb/kccgst/includer.rs
+++ b/kbvm/src/xkb/kccgst/includer.rs
@@ -114,7 +114,7 @@ impl Includer<'_, '_, '_> {
             );
             return;
         }
-        let resolved = include.loaded.get_or_insert_default();
+        let mut resolved = vec![];
         let mut iter = parse_include(interner, include.path);
         while let Some(i) = iter.next() {
             let i = match i {
@@ -131,7 +131,7 @@ impl Includer<'_, '_, '_> {
                     DiagnosticKind::MaxIncludesReached,
                     ad_hoc_display!("maximum number of includes reached").spanned2(i.file.span),
                 );
-                return;
+                break;
             }
             let mut span = i.file.span;
             if let Some(map) = i.map {
@@ -173,5 +173,6 @@ impl Includer<'_, '_, '_> {
             }
             self.active_includes.remove(&key);
         }
+        include.loaded = Some(resolved.into_boxed_slice());
     }
 }

--- a/kbvm/src/xkb/kccgst/lexer.rs
+++ b/kbvm/src/xkb/kccgst/lexer.rs
@@ -175,12 +175,12 @@ impl ItemLexer<'_> {
                 b'~' => token![~],
                 _ => break 'single_character,
             };
-            return Ok(Some(t.spanned(lo, lo + 1)));
+            return Ok(Some(t.spanned(lo, lo.saturating_add(1))));
         }
         let next = |err: LexerError, pos: usize| match self.code.get(pos) {
             Some(c) => Ok(*c),
             _ => {
-                let hi = self.span_lo + pos as SpanUnit;
+                let hi = self.span_lo.saturating_add(pos as SpanUnit);
                 Err(err.spanned(lo, hi))
             }
         };

--- a/kbvm/src/xkb/kccgst/parser.rs
+++ b/kbvm/src/xkb/kccgst/parser.rs
@@ -1287,7 +1287,13 @@ impl Parser<'_, '_, '_> {
             span.hi = last.span.hi;
             components.push(last.val);
         }
-        Ok(Path { components }.spanned2(span))
+        let path = 'path: {
+            if components.len() == 1 && components[0].index.is_none() {
+                break 'path Path::One(components[0].ident.val);
+            }
+            Path::Any(components.into_boxed_slice())
+        };
+        Ok(path.spanned2(span))
     }
 
     fn parse_path_component(
@@ -1462,7 +1468,7 @@ impl Parser<'_, '_, '_> {
                             path,
                             args: args.val,
                         };
-                        return Ok(Expr::Call(call).spanned2(span));
+                        return Ok(Expr::Call(Box::new(call)).spanned2(span));
                     }
                 }
                 Ok(Expr::Path(path.val).spanned2(path.span))

--- a/kbvm/src/xkb/rmlvo/lexer.rs
+++ b/kbvm/src/xkb/rmlvo/lexer.rs
@@ -175,8 +175,8 @@ impl LineLexer<'_> {
             };
         }
         if start == self.pos {
-            let lo = self.span_lo + self.pos as SpanUnit;
-            return Err(UnexpectedByte(b).spanned(lo, lo + 1));
+            let lo = self.span_lo.saturating_add(self.pos as SpanUnit);
+            return Err(UnexpectedByte(b).spanned(lo, lo.saturating_add(1)));
         }
         let end = self.pos;
         let value = self.interner.intern(&self.code.slice(start..end));
@@ -184,7 +184,7 @@ impl LineLexer<'_> {
             true => Token::GroupName(value),
             false => Token::Ident(value),
         };
-        let hi = self.span_lo + self.pos as SpanUnit;
+        let hi = self.span_lo.saturating_add(self.pos as SpanUnit);
         Ok(One::Token(token.spanned(lo, hi)))
     }
 }

--- a/kbvm/src/xkb/rmlvo/parser.rs
+++ b/kbvm/src/xkb/rmlvo/parser.rs
@@ -20,7 +20,7 @@ use {
                 },
                 token::{Punctuation, Token},
             },
-            span::{Span, SpanExt, Spanned},
+            span::{Span, SpanExt, SpanUnit, Spanned},
         },
     },
     kbvm_proc::ad_hoc_display,
@@ -229,7 +229,7 @@ impl Parser<'_, '_, '_> {
         for (offset, c) in val.as_bytes().iter().copied().enumerate() {
             if last_was_percent {
                 last_was_percent = false;
-                let lo = ident.span.lo + offset as u64 - 1;
+                let lo = ident.span.lo + offset as SpanUnit - 1;
                 let hi = lo + 2;
                 match c {
                     b'%' => res.extend_from_slice(b"%"),

--- a/kbvm/src/xkb/rmlvo/parser/error.rs
+++ b/kbvm/src/xkb/rmlvo/parser/error.rs
@@ -7,7 +7,7 @@ use {
             parser::Parser,
             token::{Punctuation, Token},
         },
-        span::{Span, SpanExt, Spanned},
+        span::{Span, SpanExt, SpanUnit, Spanned},
     },
     bstr::ByteSlice,
     debug_fn::debug_fn,
@@ -201,7 +201,7 @@ impl Parser<'_, '_, '_> {
         offset: usize,
     ) -> Spanned<ParserError> {
         let slice = self.interner.get(ident.val).to_owned();
-        let lo = ident.span.lo + offset as u64;
+        let lo = ident.span.lo + offset as SpanUnit;
         ParserError::IndexStart(slice[offset]).spanned(lo, lo + 1)
     }
 
@@ -214,7 +214,7 @@ impl Parser<'_, '_, '_> {
     pub(super) fn index(&self, ident: Spanned<Interned>, offset: usize) -> Spanned<ParserError> {
         let actual = self.interner.get(ident.val);
         let actual = actual.slice(offset + 1..actual.len() - 1);
-        let lo = ident.span.lo + offset as u64 + 1;
+        let lo = ident.span.lo + offset as SpanUnit + 1;
         let hi = ident.span.hi - 1;
         ParserError::Index(actual.to_owned()).spanned(lo, hi)
     }

--- a/kbvm/src/xkb/rmlvo/resolver.rs
+++ b/kbvm/src/xkb/rmlvo/resolver.rs
@@ -28,7 +28,7 @@ use {
                     RuleKey,
                 },
             },
-            span::{Span, SpanExt, Spanned},
+            span::{Span, SpanExt, SpanUnit, Spanned},
         },
     },
     hashbrown::{hash_set::Entry, HashMap, HashSet},
@@ -474,7 +474,7 @@ fn expand(
                 write!(stash.val, "{}", idx + 1).unwrap();
                 flush_once(mm, stash.as_ref().map(|s| &***s));
                 if mm.is_none() {
-                    let lo = stash.span.lo + len as u64;
+                    let lo = stash.span.lo + len as SpanUnit;
                     mm = Some(MergeMode::Override.spanned(lo, lo + 3));
                 }
             }
@@ -499,8 +499,8 @@ fn expand(
                         }
                     }
                 }
-                let lo = value.span.lo + $start as u64;
-                let hi = value.span.lo + $end as u64;
+                let lo = value.span.lo + $start as SpanUnit;
+                let hi = value.span.lo + $end as SpanUnit;
                 flush(map, includes, interner, mm, stash.spanned(lo, hi));
             }
         }};
@@ -515,7 +515,7 @@ fn expand(
                 true => MergeMode::Override,
                 false => MergeMode::Augment,
             };
-            let lo = value.span.lo + offset as u64;
+            let lo = value.span.lo + offset as SpanUnit;
             mm = Some(mode.spanned(lo, lo + 1));
             offset += 1;
             start = offset;
@@ -569,8 +569,8 @@ fn expand(
         let encoding = match encoding {
             Some(e) => e,
             _ => {
-                let lo = value.span.lo + encoding_start as u64;
-                let hi = value.span.lo + encoding_end as u64;
+                let lo = value.span.lo + encoding_start as SpanUnit;
+                let hi = value.span.lo + encoding_end as SpanUnit;
                 diagnostics.push(
                     map,
                     DiagnosticKind::InvalidPercentEncoding,
@@ -662,7 +662,7 @@ fn parse_percent_encoding(
     bytes: &[u8],
     offset: &mut usize,
     last_was_colon: bool,
-    span_lo: u64,
+    span_lo: SpanUnit,
 ) -> Option<PercentEncoding> {
     let start = *offset;
     find_percent_encoding_range(bytes, offset)?;
@@ -680,7 +680,7 @@ fn parse_percent_encoding(
             true => MergeMode::Augment,
             false => MergeMode::Override,
         };
-        let hi = span_lo + *offset as u64;
+        let hi = span_lo + *offset as SpanUnit;
         merge_mode = Some(mm.spanned(hi - 1, hi));
         bytes = &bytes[1..];
     } else if matches!(b, b'-' | b'_') {

--- a/kbvm/src/xkb/span.rs
+++ b/kbvm/src/xkb/span.rs
@@ -7,7 +7,7 @@ use {
     },
 };
 
-pub type SpanUnit = u64;
+pub type SpanUnit = u32;
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub(crate) struct Span {

--- a/kbvm/src/xkb/span.rs
+++ b/kbvm/src/xkb/span.rs
@@ -7,16 +7,18 @@ use {
     },
 };
 
+pub type SpanUnit = u64;
+
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub(crate) struct Span {
-    pub(crate) lo: u64,
-    pub(crate) hi: u64,
+    pub(crate) lo: SpanUnit,
+    pub(crate) hi: SpanUnit,
 }
 
-impl Add<u64> for Span {
+impl Add<SpanUnit> for Span {
     type Output = Self;
 
-    fn add(self, rhs: u64) -> Self::Output {
+    fn add(self, rhs: SpanUnit) -> Self::Output {
         Self {
             lo: self.lo.wrapping_add(rhs),
             hi: self.hi.wrapping_add(rhs),
@@ -94,12 +96,12 @@ impl<T> Spanned<T> {
 }
 
 pub(crate) trait SpanExt: Sized {
-    fn spanned(self, lo: u64, hi: u64) -> Spanned<Self>;
+    fn spanned(self, lo: SpanUnit, hi: SpanUnit) -> Spanned<Self>;
     fn spanned2(self, span: Span) -> Spanned<Self>;
 }
 
 impl<T> SpanExt for T {
-    fn spanned(self, lo: u64, hi: u64) -> Spanned<Self> {
+    fn spanned(self, lo: SpanUnit, hi: SpanUnit) -> Spanned<Self> {
         self.spanned2(Span { lo, hi })
     }
 

--- a/kbvm/src/xkb/string_cooker.rs
+++ b/kbvm/src/xkb/string_cooker.rs
@@ -8,7 +8,7 @@ use {
         code_slice::CodeSlice,
         diagnostic::{DiagnosticKind, DiagnosticSink},
         interner::{Interned, Interner},
-        span::{Span, SpanExt, Spanned},
+        span::{Span, SpanExt, SpanUnit, Spanned},
     },
     hashbrown::{hash_map::Entry, HashMap},
     std::sync::Arc,
@@ -88,8 +88,8 @@ impl StringCooker {
                     let _ = next!() && next!();
                     if c > 0xff {
                         let span = Span {
-                            lo: lo + start as u64,
-                            hi: lo + i as u64,
+                            lo: lo + start as SpanUnit,
+                            hi: lo + i as SpanUnit,
                         };
                         diagnostics.push(
                             map,
@@ -102,8 +102,8 @@ impl StringCooker {
                 }
                 _ => {
                     let span = Span {
-                        lo: lo + i as u64 - 1,
-                        hi: lo + i as u64,
+                        lo: lo + i as SpanUnit - 1,
+                        hi: lo + i as SpanUnit,
                     };
                     diagnostics.push(
                         map,


### PR DESCRIPTION
While runtime stuff is already highly optimized, I had so far not put any effort into optimizing the compiler.

This PR significantly optimizes the performance and memory usage of the compiler. As a result, in a synthetic benchmark with a 5MB keymap:

- KBVM uses about 2.5x the memory of xkbcommon
- KBVM uses about 1.4x the CPU time of xkbcommon

I believe that the CPU time overhead is caused by the memory overhead, page-faults and such. The number of instructions is very similar. For normal-sized keymaps, the runtime is almost the same, probably because the compiler uses very little memory for them either way.

As for the memory usage, KBVM stores and preserves a lot more information than xkbcommon to be able to print stack traces, code excerpts, and such. Some of that could be optimized because we sometimes store spans that are never used. But it's unclear how much we would gain from this. The optimizations in this PR are mostly down to shrinking the size of data structures and replacing vectors by boxed slices. This reduced the memory usage and CPU time by over 50% each.