### PR TITLE
xkb: vmod defs without values never override previous values

### DIFF
--- a/compile-tests/testcases/t04/t060/t0460/expected.xkb
+++ b/compile-tests/testcases/t04/t060/t0460/expected.xkb
@@ -1,0 +1,21 @@
+xkb_keymap {
+    xkb_keycodes {
+        minimum = 8;
+        maximum = 255;
+
+        indicator 1 = "DUMMY";
+    };
+
+    xkb_types {
+        virtual_modifiers a = Shift;
+    };
+
+    xkb_compat {
+        interpret VoidSymbol {
+            repeat = false;
+        };
+    };
+
+    xkb_symbols {
+    };
+};

--- a/compile-tests/testcases/t04/t060/t0460/input.xkb
+++ b/compile-tests/testcases/t04/t060/t0460/input.xkb
@@ -1,0 +1,6 @@
+xkb_keymap {
+    xkb_types {
+        virtual_modifiers a = 1;
+        virtual_modifiers a;
+    };
+};

--- a/kbvm/release-notes.md
+++ b/kbvm/release-notes.md
@@ -1,5 +1,30 @@
 # Unreleased
 
+- Fixed the following scenario:
+
+  ```xkb
+  xkb_types {
+      virtual_modifiers a = 1;
+      virtual_modifiers a;
+  };
+  ```
+  
+  This is now the same as
+
+  ```xkb
+  xkb_types {
+      virtual_modifiers a = 1;
+  };
+  ```
+  
+  whereas previously it was the same as
+
+  ```xkb
+  xkb_types {
+      virtual_modifiers a;
+  };
+  ```
+
 # 0.1.3 (2025-02-13)
 
 - Reduce memory usage when keymap contains large keycodes.

--- a/kbvm/src/keysym.rs
+++ b/kbvm/src/keysym.rs
@@ -90,7 +90,7 @@ const IS_UPPER: u8 = 1 << 3;
 const IS_SECONDARY_IDX: u8 = 1 << 4;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[repr(packed)]
+#[repr(Rust, packed)]
 struct KeysymData {
     keysym_or_definitive_idx: u32,
     name_start: u16,
@@ -99,14 +99,14 @@ struct KeysymData {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[repr(packed)]
+#[repr(Rust, packed)]
 struct KeysymChar {
     keysym: u16,
     char: char,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[repr(packed)]
+#[repr(Rust, packed)]
 struct KeysymCaseMapping {
     keysym: u16,
     other: u32,

--- a/kbvm/src/xkb/compose/lexer.rs
+++ b/kbvm/src/xkb/compose/lexer.rs
@@ -198,9 +198,9 @@ impl LineLexer<'_, '_, '_> {
                                     }
                                     b = self.code[self.pos];
                                     match b {
-                                        b'0'..=b'9' => c = c << 4 | (b - b'0'),
-                                        b'a'..=b'f' => c = c << 4 | (b - b'a' + 10),
-                                        b'A'..=b'F' => c = c << 4 | (b - b'A' + 10),
+                                        b'0'..=b'9' => c = (c << 4) | (b - b'0'),
+                                        b'a'..=b'f' => c = (c << 4) | (b - b'a' + 10),
+                                        b'A'..=b'F' => c = (c << 4) | (b - b'A' + 10),
                                         _ => break,
                                     }
                                     self.pos += 1;

--- a/kbvm/src/xkb/kccgst/resolver.rs
+++ b/kbvm/src/xkb/kccgst/resolver.rs
@@ -716,7 +716,9 @@ impl VmodResolver<'_, '_, '_, '_> {
             return;
         };
         if vmod.def.is_none() || vmod.def == value || mm.is_not_augment() {
-            vmod.def = value;
+            if value.is_some() {
+                vmod.def = value;
+            }
         } else {
             self.r.diag(
                 DiagnosticKind::IgnoringVmodRedefinition,


### PR DESCRIPTION
Fixed the following scenario:

```xkb
xkb_types {
    virtual_modifiers a = 1;
    virtual_modifiers a;
};
```

This is now the same as

```xkb
xkb_types {
    virtual_modifiers a = 1;
};
```

whereas previously it was the same as

```xkb
xkb_types {
    virtual_modifiers a;
};
```
