### PR TITLE
xkb: ensure that both indicator ids and names are unique

### DIFF
--- a/compile-tests/testcases/t04/t060/t0461/expected.xkb
+++ b/compile-tests/testcases/t04/t060/t0461/expected.xkb
@@ -1,0 +1,21 @@
+xkb_keymap {
+    xkb_keycodes {
+        minimum = 8;
+        maximum = 255;
+
+        indicator 1 = "B";
+    };
+
+    xkb_types {
+        virtual_modifiers Dummy;
+    };
+
+    xkb_compat {
+        interpret VoidSymbol {
+            repeat = false;
+        };
+    };
+
+    xkb_symbols {
+    };
+};

--- a/compile-tests/testcases/t04/t060/t0461/input.xkb
+++ b/compile-tests/testcases/t04/t060/t0461/input.xkb
@@ -1,0 +1,7 @@
+xkb_keymap {
+    xkb_keycodes {
+        indicator 1 = "A";
+        indicator 2 = "B";
+        indicator 1 = "B";
+    };
+};

--- a/compile-tests/testcases/t04/t060/t0462/expected.xkb
+++ b/compile-tests/testcases/t04/t060/t0462/expected.xkb
@@ -1,0 +1,22 @@
+xkb_keymap {
+    xkb_keycodes {
+        minimum = 8;
+        maximum = 255;
+
+        indicator 1 = "B";
+        indicator 3 = "C";
+    };
+
+    xkb_types {
+        virtual_modifiers Dummy;
+    };
+
+    xkb_compat {
+        interpret VoidSymbol {
+            repeat = false;
+        };
+    };
+
+    xkb_symbols {
+    };
+};

--- a/compile-tests/testcases/t04/t060/t0462/input.xkb
+++ b/compile-tests/testcases/t04/t060/t0462/input.xkb
@@ -1,0 +1,11 @@
+xkb_keymap {
+    xkb_keycodes {
+        indicator 1 = "A";
+        indicator 2 = "B";
+        indicator 1 = "A";
+        indicator 1 = "B";
+        indicator 3 = "C";
+        augment indicator 3 = "D";
+        augment indicator 3 = "B";
+    };
+};

--- a/kbvm/release-notes.md
+++ b/kbvm/release-notes.md
@@ -25,6 +25,33 @@
   };
   ```
 
+- Fixed the following scenario:
+
+  ```xkb
+  xkb_keycodes {
+      indicator 1 = "A";
+      indicator 2 = "B";
+      indicator 1 = "B";
+  };
+  ```
+  
+  Previously this would produce
+
+  ```xkb
+  xkb_keycodes {
+      indicator 1 = "B";
+      indicator 2 = "B";
+  };
+  ```
+  
+  Instead, this now produces
+
+  ```xkb
+  xkb_keycodes {
+      indicator 1 = "B";
+  };
+  ```
+
 # 0.1.3 (2025-02-13)
 
 - Reduce memory usage when keymap contains large keycodes.

--- a/kbvm/src/xkb/kccgst/resolver.rs
+++ b/kbvm/src/xkb/kccgst/resolver.rs
@@ -836,16 +836,28 @@ impl KeycodesResolver<'_, '_, '_, '_> {
         virt: Option<Span>,
     ) {
         let augment = mm.is_augment();
-        let i = Indicator { idx, name, virt };
-        for indicator in &mut self.data.indicators {
-            if indicator.idx == idx || indicator.name == name {
+        let indi = Indicator { idx, name, virt };
+        let mut i = 0;
+        while i < self.data.indicators.len() {
+            let old = &self.data.indicators[i];
+            if old.idx == idx || old.name == name {
                 if !augment {
-                    *indicator = i;
+                    self.data.indicators[i] = indi;
+                    i += 1;
+                    while i < self.data.indicators.len() {
+                        let old = &self.data.indicators[i];
+                        if old.idx == idx || old.name == name {
+                            self.data.indicators.swap_remove(i);
+                        } else {
+                            i += 1;
+                        }
+                    }
                 }
                 return;
             }
+            i += 1;
         }
-        self.data.indicators.push(i);
+        self.data.indicators.push(indi);
     }
 }
 


### PR DESCRIPTION
- Fixed the following scenario:

  ```xkb
  xkb_keycodes {
      indicator 1 = "A";
      indicator 2 = "B";
      indicator 1 = "B";
  };
  ```
  
  Previously this would produce

  ```xkb
  xkb_keycodes {
      indicator 1 = "B";
      indicator 2 = "B";
  };
  ```
  
  Instead, this now produces

  ```xkb
  xkb_keycodes {
      indicator 1 = "B";
  };
  ```

Closes #26 